### PR TITLE
Keep public marketplace facts immediately understandable

### DIFF
--- a/src/components/employee/EmployeeCard.tsx
+++ b/src/components/employee/EmployeeCard.tsx
@@ -26,18 +26,13 @@ import { useSavedEmployees } from "@/hooks/use-saved";
 import { useI18n, useMessages } from "@/i18n";
 import { localizeEmployeeContent } from "@/i18n/employee-content";
 import {
-  acceptanceText,
-  averageCostText,
   availabilityText,
   employeeEvidenceBadge,
   employeeEvidenceLevel,
-  kpiStateText,
   runtimeText,
-  taskCountText,
 } from "@/i18n/marketplace-format";
 import { marketplaceMessages } from "@/i18n/locales/marketplace";
 import { cn } from "@/lib/utils";
-import { useEmployeePerformance } from "./useEmployeePerformance";
 
 type EmployeeCardProps = {
   employee: Employee;
@@ -61,12 +56,7 @@ export function EmployeeCard({
   const displayEmployee = localizeEmployeeContent(employee, locale);
   const saved = useSavedEmployees();
   const isSaved = saved.isSaved(employee.employee_id);
-  const performanceState = useEmployeePerformance(employee.employee_id);
-  const performance = performanceState.performance;
   const runtime = runtimeText(employee, t);
-  const kpiCopy = performanceState.loading
-    ? t("loadingLocalKpiLong")
-    : kpiStateText(performance, t);
 
   return (
     <Card
@@ -180,32 +170,10 @@ export function EmployeeCard({
         <dl className="mt-4 grid grid-cols-2 gap-2 text-xs">
           <div className="rounded-[8px] border border-white/10 bg-white/[0.025] p-3">
             <dt className="font-mono uppercase tracking-[0.12em] text-crew-muted">
-              {t("formalTasks")}
+              {t("demoTasks")}
             </dt>
             <dd className="mt-1 text-sm font-semibold text-crew-heading">
-              {performanceState.loading
-                ? t("loading")
-                : taskCountText(performance, t)}
-            </dd>
-          </div>
-          <div className="rounded-[8px] border border-white/10 bg-white/[0.025] p-3">
-            <dt className="font-mono uppercase tracking-[0.12em] text-crew-muted">
-              {t("acceptance")}
-            </dt>
-            <dd className="mt-1 text-sm font-semibold text-crew-heading">
-              {performanceState.loading
-                ? t("loading")
-                : acceptanceText(performance, t)}
-            </dd>
-          </div>
-          <div className="rounded-[8px] border border-white/10 bg-white/[0.025] p-3">
-            <dt className="font-mono uppercase tracking-[0.12em] text-crew-muted">
-              {t("avgCost")}
-            </dt>
-            <dd className="mt-1 text-sm font-semibold text-crew-heading">
-              {performanceState.loading
-                ? t("loading")
-                : averageCostText(performance, t)}
+              {employee.demo_tasks.length}
             </dd>
           </div>
           <div className="rounded-[8px] border border-white/10 bg-white/[0.025] p-3">
@@ -218,8 +186,7 @@ export function EmployeeCard({
           </div>
         </dl>
         <p className="mt-3 text-xs leading-5 text-crew-muted">
-          {t("cardKpiSummary", {
-            kpi: kpiCopy,
+          {t("cardRuntimeSummary", {
             risk: runtime.highestRisk,
             runtimeDetail: runtime.detail,
           })}

--- a/src/i18n/locales/en/marketplace.ts
+++ b/src/i18n/locales/en/marketplace.ts
@@ -23,7 +23,7 @@ export const marketplaceEn = {
   role: "Role",
   tasks: "Tasks",
   tasksDemos: "Tasks / examples",
-  fieldKpi: "Field KPI",
+  demoTasks: "Example tasks",
   license: "License",
   openSource: "Open source",
   runtime: "Runtime",
@@ -77,7 +77,7 @@ export const marketplaceEn = {
   consoleCategoryAria: "Marketplace category",
   consoleEvidenceAria: "Marketplace evidence",
   consoleFooter:
-    "{count} published - receipt-backed fields stay unavailable until local work exists",
+    "{count} published - public cards show registry-backed package facts",
   consoleCommand: "$ crewclaw market --open ->",
   featuredEyebrow: "Featured",
   featuredTitle: "Recommended employees",
@@ -118,12 +118,11 @@ export const marketplaceEn = {
   compareEyebrow: "Compare",
   compareTitle: "Evidence-backed shortlist",
   compareDescription:
-    "Select two or three employees to compare package evidence, runtime readiness, receipt-backed KPI data, permission risk, and hiring availability without leaving the marketplace.",
+    "Select two or three employees to compare package evidence, example tasks, runtime readiness, license, and hiring availability without leaving the marketplace.",
   compareNeedMore:
     "Add at least one more employee. Comparison starts at two and stops at three so the table remains readable.",
   compare: "Compare",
   compared: "Compared",
-  noLedger: "no ledger",
   demos: "examples",
   localKpiUnavailable: "Local KPI unavailable",
   localKpiInvalid: "Local KPI invalid",
@@ -151,7 +150,7 @@ export const marketplaceEn = {
   clearSearch: "Clear search",
   searchComparisonTitle: "Search comparison",
   searchComparisonDescription:
-    "Compare two or three results using registry fields and receipt-backed local KPI data when it exists.",
+    "Compare two or three results using public registry fields, runtime readiness, availability, and license.",
   searchCompareNeedMore: "Add at least one more employee to compare.",
   noSearchResultsTitle: "No employees found",
   noSearchResultsDescription:
@@ -163,7 +162,7 @@ export const marketplaceEn = {
   growthStartTitle:
     "Every hire starts in manual-review mode. Three explicit acceptances unlock trust-auto eligibility; tool permissions remain governed by P0-P4.",
   formalTasks: "Formal tasks",
-  cardKpiSummary: "{kpi}. {runtimeDetail}. Highest enabled risk is {risk}.",
+  cardRuntimeSummary: "{runtimeDetail}. Highest enabled risk is {risk}.",
   noToolsDeclared: "No tools declared",
   runtimeBacked: "{ready}/{total} runtime-backed",
   adapterRequiredOne: "{count} adapter-required capability",

--- a/src/i18n/locales/zh-CN/marketplace.ts
+++ b/src/i18n/locales/zh-CN/marketplace.ts
@@ -25,7 +25,7 @@ export const marketplaceZhCN = {
   role: "角色",
   tasks: "任务",
   tasksDemos: "任务 / 示例",
-  fieldKpi: "现场 KPI",
+  demoTasks: "示例任务",
   license: "许可证",
   openSource: "开源",
   runtime: "运行时",
@@ -77,7 +77,7 @@ export const marketplaceZhCN = {
   consoleTitle: "CrewClaw 市场",
   consoleCategoryAria: "市场类别",
   consoleEvidenceAria: "市场证据",
-  consoleFooter: "{count} 个已发布 - 本地工作存在前，带回执字段会保持不可用",
+  consoleFooter: "{count} 个已发布 - 公开卡片仅展示注册表中的包信息",
   consoleCommand: "$ crewclaw market --open ->",
   featuredEyebrow: "精选",
   featuredTitle: "推荐员工",
@@ -115,12 +115,11 @@ export const marketplaceZhCN = {
   compareEyebrow: "比较",
   compareTitle: "证据背书的候选名单",
   compareDescription:
-    "选择两到三名员工，在不离开市场的情况下比较包证据、运行时就绪度、带回执 KPI 数据、权限风险和雇佣可用性。",
+    "选择两到三名员工，在不离开市场的情况下比较包证据、示例任务、运行时就绪度、许可证和雇佣可用性。",
   compareNeedMore:
     "至少再添加一名员工。比较从两名开始，最多三名，以保持表格可读。",
   compare: "比较",
   compared: "已比较",
-  noLedger: "无台账",
   demos: "示例",
   localKpiUnavailable: "本地 KPI 不可用",
   localKpiInvalid: "本地 KPI 无效",
@@ -147,7 +146,7 @@ export const marketplaceZhCN = {
   clearSearch: "清除搜索",
   searchComparisonTitle: "搜索结果比较",
   searchComparisonDescription:
-    "用注册表字段和存在时的带回执本地 KPI 数据比较两到三个结果。",
+    "用公开注册表字段、运行时就绪度、可用性和许可证比较两到三个结果。",
   searchCompareNeedMore: "至少再添加一名员工进行比较。",
   noSearchResultsTitle: "未找到员工",
   noSearchResultsDescription:
@@ -159,7 +158,7 @@ export const marketplaceZhCN = {
   growthStartTitle:
     "每次雇佣都从人工评审模式开始。三次明确接受会解锁 trust-auto 资格；工具权限仍由 P0-P4 管控。",
   formalTasks: "正式任务",
-  cardKpiSummary: "{kpi}。{runtimeDetail}。最高启用风险为 {risk}。",
+  cardRuntimeSummary: "{runtimeDetail}。最高启用风险为 {risk}。",
   noToolsDeclared: "未声明工具",
   runtimeBacked: "{ready}/{total} 个运行时支持",
   adapterRequiredOne: "{count} 个需适配器的能力",

--- a/src/i18n/public-marketplace.test.ts
+++ b/src/i18n/public-marketplace.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { marketplaceEn } from "./locales/en/marketplace";
+import { marketplaceZhCN } from "./locales/zh-CN/marketplace";
+
+const localKpiImplementation =
+  /useEmployeePerformance|taskCountText|acceptanceText|averageCostText|kpiStateText/;
+const unavailableLocalKpiCopy =
+  /unavailable|local KPI|receipt-backed KPI|不可用|本地 KPI|带回执 KPI/i;
+
+describe("public marketplace facts", () => {
+  it("keeps local KPI reads out of public discovery surfaces", () => {
+    const publicDiscoverySources = [
+      join(process.cwd(), "src", "components", "employee", "EmployeeCard.tsx"),
+      join(process.cwd(), "src", "pages", "Marketplace.tsx"),
+      join(process.cwd(), "src", "pages", "Search.tsx"),
+    ];
+
+    for (const source of publicDiscoverySources) {
+      expect(readFileSync(source, "utf8"), source).not.toMatch(
+        localKpiImplementation
+      );
+    }
+  });
+
+  it("describes comparisons using public registry facts", () => {
+    const publicCopy = [
+      marketplaceEn.consoleFooter,
+      marketplaceEn.compareDescription,
+      marketplaceEn.searchComparisonDescription,
+      marketplaceZhCN.consoleFooter,
+      marketplaceZhCN.compareDescription,
+      marketplaceZhCN.searchComparisonDescription,
+    ];
+
+    for (const copy of publicCopy) {
+      expect(copy).not.toMatch(unavailableLocalKpiCopy);
+    }
+  });
+});

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -29,15 +29,12 @@ import {
   localizeEmployees,
 } from "@/i18n/employee-content";
 import {
-  acceptanceText,
-  averageCostText,
   availabilityText,
   categoryLabel,
+  employeeEvidenceLevel,
   evidenceFilterLabel,
   type MarketplaceT,
-  reputationText,
   runtimeText,
-  taskCountText,
 } from "@/i18n/marketplace-format";
 import {
   marketplaceMessages,
@@ -57,7 +54,6 @@ import {
   matchesEmployeeQuery,
   type EmployeeEvidenceFilter,
 } from "@/components/employee/employeeSignals";
-import { useEmployeePerformance } from "@/components/employee/useEmployeePerformance";
 import type { Employee } from "@/data/employees";
 
 const categoryLinks = [
@@ -113,7 +109,6 @@ function CompareEmployeeColumn({
   employee: Employee;
   t: MarketplaceT;
 }) {
-  const { loading, performance } = useEmployeePerformance(employee.employee_id);
   const runtime = runtimeText(employee, t);
 
   return (
@@ -130,21 +125,13 @@ function CompareEmployeeColumn({
         </p>
       </CompareCell>
       <CompareCell>{employee.certification}</CompareCell>
-      <CompareCell>
-        {loading ? t("loadingLocalKpi") : taskCountText(performance, t)}
-      </CompareCell>
-      <CompareCell>
-        {loading ? t("loadingLocalKpi") : acceptanceText(performance, t)}
-      </CompareCell>
-      <CompareCell>
-        {loading ? t("loadingLocalKpi") : averageCostText(performance, t)}
-      </CompareCell>
+      <CompareCell>{employee.demo_tasks.length}</CompareCell>
       <CompareCell>
         <span className="block text-crew-heading">{runtime.label}</span>
         <span className="text-xs text-crew-muted">{runtime.detail}</span>
       </CompareCell>
       <CompareCell>{availabilityText(employee, t)}</CompareCell>
-      <CompareCell>{reputationText(performance, t)}</CompareCell>
+      <CompareCell>Apache-2.0</CompareCell>
       <CompareCell>
         <Button
           asChild
@@ -166,9 +153,7 @@ function MarketplaceConsoleRow({
   employee: Employee;
   t: MarketplaceT;
 }) {
-  const { performance } = useEmployeePerformance(employee.employee_id);
   const runtime = runtimeText(employee, t);
-  const hasLocalPerformance = performance?.kpi.state === "available";
 
   return (
     <Link
@@ -182,16 +167,12 @@ function MarketplaceConsoleRow({
         {employee.identity.title}
       </span>
       <span>
-        {hasLocalPerformance
-          ? taskCountText(performance, t)
-          : `${employee.demo_tasks.length} ${t("demos")}`}
+        {employee.demo_tasks.length} {t("demos")}
       </span>
       <span className="text-emerald-300">
-        {hasLocalPerformance ? acceptanceText(performance, t) : t("noLedger")}
+        {employeeEvidenceLevel(employee, t)}
       </span>
-      <span>
-        {hasLocalPerformance ? averageCostText(performance, t) : "Apache-2.0"}
-      </span>
+      <span>Apache-2.0</span>
       <span className="flex items-center justify-between gap-2">
         <span>{runtime.label}</span>
         <span className="text-emerald-300" aria-hidden="true">
@@ -248,17 +229,15 @@ function ComparePanel({
         </p>
       ) : (
         <div className="mt-5 overflow-x-auto">
-          <table className="min-w-[920px] w-full border-collapse">
+          <table className="min-w-[760px] w-full border-collapse">
             <thead>
               <tr className="text-left font-mono text-[11px] uppercase tracking-[0.14em] text-crew-muted">
                 <th className="px-3 py-2">{t("employee")}</th>
                 <th className="px-3 py-2">{t("cert")}</th>
-                <th className="px-3 py-2">{t("tasks")}</th>
-                <th className="px-3 py-2">{t("acceptance")}</th>
-                <th className="px-3 py-2">{t("avgCost")}</th>
+                <th className="px-3 py-2">{t("demoTasks")}</th>
                 <th className="px-3 py-2">{t("runtime")}</th>
                 <th className="px-3 py-2">{t("availability")}</th>
-                <th className="px-3 py-2">{t("reputation")}</th>
+                <th className="px-3 py-2">{t("license")}</th>
                 <th className="px-3 py-2">{t("next")}</th>
               </tr>
             </thead>
@@ -632,7 +611,7 @@ export default function Marketplace() {
             <span>{t("employee")}</span>
             <span>{t("role")}</span>
             <span>{t("tasksDemos")}</span>
-            <span>{t("fieldKpi")}</span>
+            <span>{t("evidence")}</span>
             <span>{t("license")}</span>
             <span>{t("runtime")}</span>
           </div>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -20,13 +20,11 @@ import { track } from "@/hooks/use-analytics";
 import { useI18n, useMessages } from "@/i18n";
 import { localizeEmployees } from "@/i18n/employee-content";
 import {
-  acceptanceText,
-  averageCostText,
+  availabilityText,
   categoryLabel,
   evidenceFilterLabel,
   type MarketplaceT,
   runtimeText,
-  taskCountText,
 } from "@/i18n/marketplace-format";
 import {
   marketplaceMessages,
@@ -45,7 +43,6 @@ import {
   matchesEmployeeQuery,
   type EmployeeEvidenceFilter,
 } from "@/components/employee/employeeSignals";
-import { useEmployeePerformance } from "@/components/employee/useEmployeePerformance";
 
 const categoryLinks = [
   { value: "" },
@@ -85,7 +82,6 @@ function SearchCompareRow({
   employee: Employee;
   t: MarketplaceT;
 }) {
-  const { loading, performance } = useEmployeePerformance(employee.employee_id);
   const runtime = runtimeText(employee, t);
 
   return (
@@ -112,26 +108,10 @@ function SearchCompareRow({
       <dl className="mt-4 grid gap-2 text-xs sm:grid-cols-4">
         <div>
           <dt className="font-mono uppercase tracking-[0.12em] text-crew-muted">
-            {t("tasks")}
+            {t("demoTasks")}
           </dt>
           <dd className="mt-1 text-crew-heading">
-            {loading ? t("loading") : taskCountText(performance, t)}
-          </dd>
-        </div>
-        <div>
-          <dt className="font-mono uppercase tracking-[0.12em] text-crew-muted">
-            {t("acceptance")}
-          </dt>
-          <dd className="mt-1 text-crew-heading">
-            {loading ? t("loading") : acceptanceText(performance, t)}
-          </dd>
-        </div>
-        <div>
-          <dt className="font-mono uppercase tracking-[0.12em] text-crew-muted">
-            {t("cost")}
-          </dt>
-          <dd className="mt-1 text-crew-heading">
-            {loading ? t("loading") : averageCostText(performance, t)}
+            {employee.demo_tasks.length}
           </dd>
         </div>
         <div>
@@ -139,6 +119,20 @@ function SearchCompareRow({
             {t("runtime")}
           </dt>
           <dd className="mt-1 text-crew-heading">{runtime.label}</dd>
+        </div>
+        <div>
+          <dt className="font-mono uppercase tracking-[0.12em] text-crew-muted">
+            {t("availability")}
+          </dt>
+          <dd className="mt-1 text-crew-heading">
+            {availabilityText(employee, t)}
+          </dd>
+        </div>
+        <div>
+          <dt className="font-mono uppercase tracking-[0.12em] text-crew-muted">
+            {t("license")}
+          </dt>
+          <dd className="mt-1 text-crew-heading">Apache-2.0</dd>
         </div>
       </dl>
     </article>


### PR DESCRIPTION
## What changed

- Replaced the public employee-card KPI grid with registry-backed example-task and runtime facts.
- Removed local task, acceptance, average-cost, and reputation reads from marketplace and search comparisons.
- Updated the console and comparison copy in English and Chinese to describe only public package facts.
- Added a regression test that keeps local KPI reads and misleading unavailable copy out of public discovery surfaces.

## Why

The hosted Fly deployment cannot read CrewClaw's loopback-only local KPI ledger. Showing those fields as “Unavailable / 不可用” made healthy employee packages look broken and gave public-page prominence to data that can only exist after local installation and real task receipts.

## Impact

Public discovery now shows only values visitors can understand and verify: examples, evidence, runtime readiness, availability, license, version, and source. Local receipt-backed KPIs remain available in the dedicated local performance surfaces.

## Validation

- `pnpm run check`
- Targeted ESLint on all changed TypeScript files
- `pnpm run test:unit` — 39 files, 301 tests passed
- `pnpm run build:web`
- Local production-browser verification in Chinese; no “不可用” values remain on marketplace cards
- Visual QA: 96/100, pass